### PR TITLE
Upgrade color package to version 5.0.0 and refactor imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,13 @@
       "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
-        "color": "^4.2.3",
+        "color": "^5.0.0",
         "eventemitter3": "^5.0.1"
       },
       "devDependencies": {
         "@masatomakino/gulptask-demo-page": "^0.8.3",
         "@masatomakino/release-helper": "^0.1.7",
         "@tweenjs/tween.js": "^25.0.0",
-        "@types/color": "^4.2.0",
         "@vitest/browser": "*",
         "@vitest/coverage-istanbul": "^3.0.5",
         "husky": "^9.1.3",
@@ -3146,30 +3145,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/color": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@types/color/-/color-4.2.0.tgz",
-      "integrity": "sha512-6+xrIRImMtGAL2X3qYkd02Mgs+gFGs+WsK0b7VVMaO4mYRISwyTjcqNrO0mNSmYEoq++rSLDB2F5HDNmqfOe+A==",
-      "dev": true,
-      "dependencies": {
-        "@types/color-convert": "*"
-      }
-    },
-    "node_modules/@types/color-convert": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.3.tgz",
-      "integrity": "sha512-2Q6wzrNiuEvYxVQqhh7sXM2mhIhvZR/Paq4FdsQkOMgWsCIkKvSGj8Le1/XalulrmgOzPMqNa0ix+ePY4hTrfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/color-name": "*"
-      }
-    },
-    "node_modules/@types/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-87W6MJCKZYDhLAx/J1ikW8niMvmGRyY+rpUxWpL1cO7F8Uu5CHuQoFv+R0/L5pgNdW4jTyda42kv60uwVIPjLw==",
-      "dev": true
-    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -4705,21 +4680,23 @@
       }
     },
     "node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.0.tgz",
+      "integrity": "sha512-16BlyiuyLq3MLxpRWyOTiWsO3ii/eLQLJUQXBSNcxMBBSnyt1ee9YUdaozQp03ifwm5woztEZGDbk9RGVuCsdw==",
+      "license": "MIT",
       "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
+        "color-convert": "^3.0.1",
+        "color-string": "^2.0.0"
       },
       "engines": {
-        "node": ">=12.5.0"
+        "node": ">=18"
       }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4732,15 +4709,49 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.0.1.tgz",
+      "integrity": "sha512-5z9FbYTZPAo8iKsNEqRNv+OlpBbDcoE+SY9GjLfDUHEfcNNV7tS9eSAlFHEaub/r5tBL9LtskAeq1l9SaoZ5tQ==",
+      "license": "MIT",
       "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.0.1.tgz",
+      "integrity": "sha512-5kQah2eolfQV7HCrxtsBBArPfT5dwaKYMCXeMQsdRO7ihTO/cuNLGjd50ITCDn+ZU/YbS0Go64SjP9154eopxg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/colorette": {
@@ -8574,19 +8585,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "node_modules/sirv": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -45,14 +45,13 @@
     "@tweenjs/tween.js": "21.0.0 - 25.x.x"
   },
   "dependencies": {
-    "color": "^4.2.3",
+    "color": "^5.0.0",
     "eventemitter3": "^5.0.1"
   },
   "devDependencies": {
     "@masatomakino/gulptask-demo-page": "^0.8.3",
     "@masatomakino/release-helper": "^0.1.7",
     "@tweenjs/tween.js": "^25.0.0",
-    "@types/color": "^4.2.0",
     "@vitest/browser": "*",
     "@vitest/coverage-istanbul": "^3.0.5",
     "husky": "^9.1.3",

--- a/src/color/HSLColor.ts
+++ b/src/color/HSLColor.ts
@@ -1,4 +1,4 @@
-import Color from "color";
+import Color, { ColorInstance } from "color";
 import { RGBColor } from "./index.js";
 
 export class HSLColor {
@@ -6,7 +6,7 @@ export class HSLColor {
     public h: number = 0,
     public s: number = 0,
     public l: number = 0,
-    public alpha: number = 1.0
+    public alpha: number = 1.0,
   ) {}
 
   toRGB(): RGBColor {
@@ -15,17 +15,12 @@ export class HSLColor {
       hslObj.red(),
       hslObj.green(),
       hslObj.blue(),
-      hslObj.alpha()
+      hslObj.alpha(),
     );
   }
 
-  private toColor(): Color {
-    return Color.hsl({
-      h: this.h,
-      l: this.l,
-      s: this.s,
-      alpha: this.alpha,
-    });
+  private toColor(): ColorInstance {
+    return Color.hsl({ h: this.h, l: this.l, s: this.s, alpha: this.alpha });
   }
 
   set(rgbObj: RGBColor): void {

--- a/src/color/RGBColor.ts
+++ b/src/color/RGBColor.ts
@@ -1,4 +1,4 @@
-import Color from "color";
+import { ColorInstance } from "color";
 import { HSLColor } from "./index.js";
 
 export class RGBColor {
@@ -6,15 +6,15 @@ export class RGBColor {
     public r: number = 0,
     public g: number = 0,
     public b: number = 0,
-    public alpha: number = 1.0
+    public alpha: number = 1.0,
   ) {}
 
-  static fromColor(color: Color): RGBColor {
+  static fromColor(color: ColorInstance): RGBColor {
     return new RGBColor(
       color.red(),
       color.green(),
       color.blue(),
-      color.alpha()
+      color.alpha(),
     );
   }
 


### PR DESCRIPTION
Upgrade the color package to version 5.0.0 and adjust the imports in the codebase to accommodate the new version's API changes.